### PR TITLE
Fix segfault in CallbackWrapper

### DIFF
--- a/acsylla/_cython/session/session.pyx
+++ b/acsylla/_cython/session/session.pyx
@@ -1,6 +1,5 @@
 import asyncio
 
-
 cdef class Session:
     def __cinit__(self, Cluster cluster, object keyspace):
         self.cass_cluster = cluster.cass_cluster
@@ -40,7 +39,7 @@ cdef class Session:
         cb_wrapper = CallbackWrapper.new_(cass_future, self.loop)
 
         try:
-            await cb_wrapper.__await__()
+            await asyncio.shield(cb_wrapper.__await__())
             cass_error = cass_future_error_code(cass_future)
             cass_future_error_message(cass_future, <const char**> &error_message, <size_t *> &length)
             raise_if_error(cass_error, error_message)
@@ -66,7 +65,7 @@ cdef class Session:
         cb_wrapper = CallbackWrapper.new_(cass_future, self.loop)
 
         try:
-            await cb_wrapper.__await__()
+            await asyncio.shield(cb_wrapper.__await__())
             cass_error = cass_future_error_code(cass_future)
             cass_future_error_message(cass_future, <const char**> &error_message, <size_t *> &length)
             raise_if_error(cass_error, error_message)
@@ -96,13 +95,12 @@ cdef class Session:
         cb_wrapper = CallbackWrapper.new_(cass_future, self.loop)
 
         try:
-            await cb_wrapper.__await__()
+            await asyncio.shield(cb_wrapper.__await__())
             cass_result = cass_future_get_result(cass_future)
             if cass_result == NULL:
                 cass_error = cass_future_error_code(cass_future)
                 cass_future_error_message(cass_future, <const char**> &error_message, <size_t*> &length)
                 raise_if_error(cass_error, error_message)
-
             result = Result.new_(cass_result)
         finally:
             cass_future_free(cass_future)
@@ -130,7 +128,7 @@ cdef class Session:
         cb_wrapper = CallbackWrapper.new_(cass_future, self.loop)
 
         try:
-            await cb_wrapper.__await__()
+            await asyncio.shield(cb_wrapper.__await__())
             cass_prepared = cass_future_get_prepared(cass_future)
             if cass_prepared == NULL:
                 cass_error = cass_future_error_code(cass_future)
@@ -168,7 +166,7 @@ cdef class Session:
         cb_wrapper = CallbackWrapper.new_(cass_future, self.loop)
 
         try:
-            await cb_wrapper.__await__()
+            await asyncio.shield(cb_wrapper.__await__())
             cass_result = cass_future_get_result(cass_future)
             if cass_result == NULL:
                 cass_error = cass_future_error_code(cass_future)


### PR DESCRIPTION
How to reproduce 

```python
import asyncio

from acsylla import create_cluster, create_statement, SSLVerifyFlags


async def main(contact_points, count):
    cluster = create_cluster(contact_points, port=9042,
                             ssl_enabled=True,
                             ssl_verify_flags=SSLVerifyFlags.NONE,
                             username='cassandra',
                             password='cassandra'
                             )
    session = await cluster.create_session()
    await session.execute(
        create_statement("CREATE KEYSPACE IF NOT EXISTS acsylla WITH "
                         "replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"))
    await session.execute(
        create_statement("CREATE TABLE IF NOT EXISTS acsylla.test (id int PRIMARY KEY, value text)"))
    prepared = await session.create_prepared("INSERT INTO acsylla.test (id, value) VALUES (:id, :value);")
    for i in range(count):
        statement = prepared.bind()
        statement.bind_dict({'id': i, 'value': str(i)})
        asyncio.create_task(session.execute(statement))
    await asyncio.sleep(5)


asyncio.run(main(["localhost"], 20_000))
```
bt
```
* thread #1, stop reason = signal SIGSTOP
  * frame #0: 0x0000000000000003
    frame #1: 0x000000010af3a48a cyacsylla.cpython-39-darwin.so`__pyx_pw_7acsylla_7_cython_9cyacsylla_1_handle_events(_object*, _object*) + 362
    frame #2: 0x000000010acd3074 loop.cpython-39-darwin.so`__Pyx_PyObject_CallNoArg + 132
    frame #3: 0x000000010acf8281 loop.cpython-39-darwin.so`__pyx_f_6uvloop_4loop_6Handle__run + 3825
    frame #4: 0x000000010ad7f55f loop.cpython-39-darwin.so`__pyx_f_6uvloop_4loop___on_uvpoll_event + 399
    frame #5: 0x000000010adc68bf loop.cpython-39-darwin.so`uv__io_poll + 2095
    frame #6: 0x000000010adb5271 loop.cpython-39-darwin.so`uv_run + 433
    frame #7: 0x000000010ace0427 loop.cpython-39-darwin.so`__pyx_f_6uvloop_4loop_4Loop___run + 39
    frame #8: 0x000000010ace0666 loop.cpython-39-darwin.so`__pyx_f_6uvloop_4loop_4Loop__run + 422
    frame #9: 0x000000010ad3ab37 loop.cpython-39-darwin.so`__pyx_pw_6uvloop_4loop_4Loop_25run_forever + 727
    frame #10: 0x000000010acd3074 loop.cpython-39-darwin.so`__Pyx_PyObject_CallNoArg + 132
    frame #11: 0x000000010ad3d505 loop.cpython-39-darwin.so`__pyx_pw_6uvloop_4loop_4Loop_45run_until_complete + 2485
    frame #12: 0x0000000109f2ae93 Python`method_vectorcall_O + 101
    frame #13: 0x000000010a017a30 Python`call_function + 168
    frame #14: 0x000000010a010001 Python`_PyEval_EvalFrameDefault + 23459
    frame #15: 0x000000010a009364 Python`_PyEval_EvalCode + 411
    frame #16: 0x0000000109f1f838 Python`_PyFunction_Vectorcall + 373
    frame #17: 0x000000010a017a30 Python`call_function + 168
    frame #18: 0x000000010a010fc4 Python`_PyEval_EvalFrameDefault + 27494
    frame #19: 0x000000010a009364 Python`_PyEval_EvalCode + 411
    frame #20: 0x000000010a064586 Python`run_eval_code_obj + 128
    frame #21: 0x000000010a0644d4 Python`run_mod + 96
    frame #22: 0x000000010a061e2f Python`pyrun_file + 167
    frame #23: 0x000000010a061816 Python`pyrun_simple_file + 271
    frame #24: 0x000000010a0616e1 Python`PyRun_SimpleFileExFlags + 67
    frame #25: 0x000000010a081229 Python`pymain_run_file + 326
    frame #26: 0x000000010a080a69 Python`Py_RunMain + 1007
    frame #27: 0x000000010a081b2f Python`pymain_main + 35
    frame #28: 0x000000010a081e05 Python`Py_BytesMain + 42
    frame #29: 0x00007fff20529f3d libdyld.dylib`start + 1
    frame #30: 0x00007fff20529f3d libdyld.dylib`start + 1
```
More real world example

```python
import random

from aiohttp import web
from acsylla import create_cluster, create_statement


async def init_db(contact_points, **kwargs):
    cluster = create_cluster(contact_points, **kwargs)
    session = await cluster.create_session()
    await session.execute(
        create_statement("CREATE KEYSPACE IF NOT EXISTS acsylla WITH "
                         "replication = {'class': 'SimpleStrategy', 'replication_factor': 1}"))
    await session.execute(
        create_statement("CREATE TABLE IF NOT EXISTS acsylla.test (id int PRIMARY KEY, value text)"))
    insert = await session.create_prepared("INSERT INTO acsylla.test (id, value) VALUES (:id, :value);")
    select = await session.create_prepared("SELECT id, value FROM acsylla.test WHERE id = :id")

    return session, insert, select


async def test(request):
    session, insert, select = request.app.db
    value = random.randint(0, 1_000_000)
    data = {'id': value, 'value': str(value)}
    statement = insert.bind()
    statement.bind_dict(data)
    await session.execute(statement)
    statement = select.bind()
    statement.bind_list([data['id']])
    responce = await session.execute(statement)
    return web.json_response([dict(k) for k in responce])


async def setup(contact_points, **kwargs):
    app = web.Application()
    app.add_routes([web.get('/test', test)])
    app.db = await init_db(contact_points, **kwargs)
    return app

if __name__ == '__main__':
    web.run_app(setup(["localhost"]))
```
Then run wrk for example
```bash
% wrk -c 100 -d 3 http://localhost:8080/test
```

@pfreixes I finded workaround with asynio.sheld but maybe you know best way to solve this?

