### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci-linux-aarch64.yml
+++ b/.github/workflows/ci-linux-aarch64.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci-linux-x86_64.yml
+++ b/.github/workflows/ci-linux-x86_64.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci-musllinux-aarch64.yml
+++ b/.github/workflows/ci-musllinux-aarch64.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci-musllinux-x86_64.yml
+++ b/.github/workflows/ci-musllinux-x86_64.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release-linux-aarch64.yml
+++ b/.github/workflows/release-linux-aarch64.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release-linux-x86_64.yml
+++ b/.github/workflows/release-linux-x86_64.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release-musllinux-aarch64.yml
+++ b/.github/workflows/release-musllinux-aarch64.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release-musllinux-x86_64.yml
+++ b/.github/workflows/release-musllinux-x86_64.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.14t" ]
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 - Improve performance
 - Update LIBUV_VERSION to 1.52.1
 - Add build for musllinux
+- Remove Python 3.8 from CI
 
 1.0.2
 ======

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Cassandra's native protocol. The current version works with:
 
 * Scylla and Scylla Enterprise
 * Apache Cassandra® versions 2.1, 2.2 and 3.0+
-* Python 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 for Linux and MacOS  
+* Python 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 for Linux and MacOS  
 
 ## Install
 


### PR DESCRIPTION
@pfreixes well, we're definitely not slowpokes, but while we were cooking up the new release, pypa/manylinux managed to yeet 3.8 out the door)))